### PR TITLE
Fixes the mixed up readable and writable

### DIFF
--- a/lib/sftp-wrapper.js
+++ b/lib/sftp-wrapper.js
@@ -7,7 +7,7 @@ module.exports = SFTPWrapper;
 SFTPWrapper.prototype.list = function (path, useCompression, cb) {
 	var self = this
 		, regDash = /-/gi
-	
+
 	cb = arguments[arguments.length - 1];
 
 	self.readdir(path, function (err, data) {
@@ -48,7 +48,7 @@ SFTPWrapper.prototype.mkdir = function (path, recursive, cb) {
 		cb = recursive;
 		recursive = false;
 	}
-	
+
 	if (!recursive) {
 		return self.__mkdir(path, cb);
 	}
@@ -114,7 +114,7 @@ SFTPWrapper.prototype.put = function (input, destPath, useCompression, cb) {
 		return stream.end(input);
 	}
 
-	return stream.pipe(input);
+	return input.pipe(stream);
 };
 
 SFTPWrapper.prototype.delete = function (path, cb) {


### PR DESCRIPTION
Readable been mixed up with Writable. This caused an exception when I tried to `put` readable stream:

```
DEBUG[SFTP]: Outgoing: Writing OPEN
DEBUG: Outgoing: Writing CHANNEL_DATA (0)
error:  Error: Cannot pipe. Not readable.
    at WriteStream.Writable.pipe (_stream_writable.js:154:22)
    at SFTPWrapper.put (/Volumes/Projects/batchman/node_modules/sftpjs/lib/sftp-wrapper.js:117:16)
```
