### PR TITLE
hot fix of "Cannot read property 'join' of undefined" using node v0.1…

### DIFF
--- a/lib/sftp-wrapper.js
+++ b/lib/sftp-wrapper.js
@@ -1,5 +1,6 @@
 var SFTPWrapper = require('ssh2/lib/SFTPWrapper')
-	, join = require('path').posix.join
+	, path = require('path')
+	, join = path.posix ? path.posix.join : path.join
 	;
 
 module.exports = SFTPWrapper;


### PR DESCRIPTION
Added ternary check to use posix.join or simple join